### PR TITLE
Fix: Update README.md to fix got a warning when run Platane/snk/svg-only action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Available as github action. Automatically generate a new image at the end of the
 **github action**
 
 ```yaml
-- uses: Platane/snk@v2.0.0-rc.1
+- uses: Platane/snk@v2.0.0-rc.3
   with:
     # github user name to read the contribution graph from (**required**)
     # using action context var `github.repository_owner` or specified user
@@ -37,7 +37,7 @@ Available as github action. Automatically generate a new image at the end of the
 
 [example with cron job](https://github.com/Platane/Platane/blob/master/.github/workflows/main.yml#L24-L29)
 
-If you are only interested in generating a svg, you can use this other faster action: `uses: Platane/snk/svg-only@v2.0.0-rc.1`
+If you are only interested in generating a svg, you can use this other faster action: `uses: Platane/snk/svg-only@v2.0.0-rc.3`
 
 **interactive demo**
 


### PR DESCRIPTION
This PR is to fix got a warning when run svg-only action.

# Issue
This is petty issue.
Got a warning when run `Platane/snk/svg-only@v2.0.0-rc.1` as per sample which written in [Usage](https://github.com/Platane/snk#usage) of README.md.
> Warning: Unexpected input(s) 'outputs', valid inputs are ['github_user_name', 'svg_out_path']

<img width="491" alt="Screen Shot 2022-04-19 at 0 08 54" src="https://user-images.githubusercontent.com/61895076/163828904-e11fd1bd-02f7-49ff-82a5-3a79e8c78b60.png">

# Version
`v2.0.0-rc.1`

# Cause
version of `Platane/snk/svg-only ` which written in README.md is old. It shoud be `v2.0.0-rc.3` not `v2.0.0-rc.1`.

Related commis is https://github.com/Platane/snk/commit/c21e390ca9edfe0edecec2109d6a0779678597ab. As you know, `svg_out_path` was replaced to `outputs`.

# Confirmation
Warning had disappeared after changing the version.
<img width="1054" alt="Screen Shot 2022-04-19 at 0 33 45" src="https://user-images.githubusercontent.com/61895076/163832878-fc7fa5dd-90a4-42fd-80c3-4901bad86078.png">
