### PR TITLE
Use input instead of env to receive GitHub token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,6 @@ jobs:
             dist/github-contribution-grid-snake.svg
             dist/github-contribution-grid-snake-dark.svg?palette=github-dark
             dist/github-contribution-grid-snake.gif?color_snake=orange&color_dots=#bfd6f6,#8dbdff,#64a1f4,#4b91f1,#3c7dd9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ensure the generated file exists
         run: |
@@ -79,8 +77,6 @@ jobs:
           outputs: |
             dist/github-contribution-grid-snake.svg
             dist/github-contribution-grid-snake-dark.svg?palette=github-dark
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ensure the generated file exists
         run: |

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   github_user_name:
     description: "github user name"
     required: true
+  github_token:
+    description: "github token used to fetch the contribution calendar. Default to the action token if empty."
+    required: false
+    default: ${{ github.token }}
   outputs:
     required: false
     default: null

--- a/packages/action/__tests__/generateContributionSnake.spec.ts
+++ b/packages/action/__tests__/generateContributionSnake.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as core from "@actions/core";
 import { generateContributionSnake } from "../generateContributionSnake";
 import { parseOutputsOption } from "../outputsOptions";
 import { config } from "dotenv";
@@ -33,7 +34,7 @@ it(
     const outputs = parseOutputsOption(entries);
 
     const results = await generateContributionSnake("platane", outputs, {
-      githubToken: process.env.GITHUB_TOKEN!,
+      githubToken: core.getInput("github_token"),
     });
 
     expect(results[0]).toBeDefined();

--- a/packages/action/index.ts
+++ b/packages/action/index.ts
@@ -12,7 +12,8 @@ import { parseOutputsOption } from "./outputsOptions";
         core.getInput("svg_out_path"),
       ]
     );
-    const githubToken = process.env.GITHUB_TOKEN!;
+    const githubToken =
+      process.env.GITHUB_TOKEN ?? core.getInput("github_token");
 
     const { generateContributionSnake } = await import(
       "./generateContributionSnake"

--- a/packages/demo/webpack.config.ts
+++ b/packages/demo/webpack.config.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import webpack from "webpack";
+import * as core from "@actions/core";
 import { getGithubUserContribution } from "@snk/github-user-contribution";
 import { config } from "dotenv";
 import type { Configuration as WebpackConfiguration } from "webpack";
@@ -16,7 +17,8 @@ const webpackDevServerConfiguration: WebpackDevServerConfiguration = {
       const userName: string = req.params.userName;
       res.send(
         await getGithubUserContribution(userName, {
-          githubToken: process.env.GITHUB_TOKEN!,
+          githubToken:
+            process.env.GITHUB_TOKEN ?? core.getInput("github_token"),
         })
       );
     });

--- a/packages/github-user-contribution-service/api/github-user-contribution/[userName].ts
+++ b/packages/github-user-contribution-service/api/github-user-contribution/[userName].ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import { getGithubUserContribution } from "@snk/github-user-contribution";
 import { VercelRequest, VercelResponse } from "@vercel/node";
 import nodeFetch from "node-fetch";
@@ -12,7 +13,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     res.statusCode = 200;
     res.json(
       await getGithubUserContribution(userName as string, {
-        githubToken: process.env.GITHUB_TOKEN!,
+        githubToken: process.env.GITHUB_TOKEN ?? core.getInput("github_token"),
       })
     );
   } catch (err) {

--- a/packages/github-user-contribution/__tests__/getGithubUserContribution.spec.ts
+++ b/packages/github-user-contribution/__tests__/getGithubUserContribution.spec.ts
@@ -1,18 +1,14 @@
+import * as core from "@actions/core";
 import { getGithubUserContribution } from "..";
 import { config } from "dotenv";
 config({ path: __dirname + "/../../../.env" });
 
 describe("getGithubUserContribution", () => {
   const promise = getGithubUserContribution("platane", {
-    githubToken: process.env.GITHUB_TOKEN!,
+    githubToken: process.env.GITHUB_TOKEN ?? core.getInput("github_token"),
   });
 
   it("should resolve", async () => {
-    console.log(
-      "process.env.GITHUB_TOKEN",
-      process.env.GITHUB_TOKEN?.replace(/\d/g, "x")
-    );
-
     await promise;
   });
 

--- a/svg-only/action.yml
+++ b/svg-only/action.yml
@@ -10,6 +10,10 @@ inputs:
   github_user_name:
     description: "github user name"
     required: true
+  github_token:
+    description: "github token used to fetch the contribution calendar. Default to the action token if empty."
+    required: false
+    default: ${{ github.token }}
   outputs:
     required: false
     default: null


### PR DESCRIPTION
The GitHub token is automatically applied to `input` as a default value.
This eliminates the need to explicitly specify a token when using action.