### PR TITLE
feat: add support for calendar year selection and date ranges

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ description: "Generates a snake game from a github user contributions grid. Outp
 author: "platane"
 
 runs:
-  using: docker
-  image: docker://platane/snk@sha256:3a66a51ca8eaecc1e841bc8baae39bd88079e57419850d1ed005eee2bbfce940
+  using: 'node20'
+  main: 'packages/action/dist/index.js'
 
 inputs:
   github_user_name:

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,24 @@ inputs:
   github_user_name:
     description: "github user name"
     required: true
+
   github_token:
     description: "github token used to fetch the contribution calendar. Default to the action token if empty."
     required: false
     default: ${{ github.token }}
+
+  year:
+    description: "Contribution year to render"
+    required: false
+
+  from:
+    description: "Contribution start date (ISO-8601)"
+    required: false
+
+  to:
+    description: "Contribution end date (ISO-8601)"
+    required: false
+
   outputs:
     required: false
     description: |

--- a/packages/action/index.ts
+++ b/packages/action/index.ts
@@ -10,6 +10,10 @@ import * as githubAction from "./github-action";
     const githubToken =
       process.env.GITHUB_TOKEN ?? githubAction.getInput("github_token");
 
+    const year = githubAction.getInput("year");
+    const from = githubAction.getInput("from");
+    const to = githubAction.getInput("to");
+
     const outputsRaw = [
       ...githubAction.getInput("outputs").split("\n"),
       //
@@ -23,7 +27,14 @@ import * as githubAction from "./github-action";
     const outputs = parseOutputsOption(outputsRaw);
 
     const results = await generateSnakeAnimation(
-      { platform: "github", username: userName, githubToken },
+      { 
+        platform: "github", 
+        username: userName, 
+        githubToken,
+        year: year ? Number(year) : undefined,
+        from: from || undefined,
+        to: to || undefined
+      },
       outputs,
     );
 

--- a/packages/generate-snake-animation/cli.ts
+++ b/packages/generate-snake-animation/cli.ts
@@ -28,11 +28,14 @@ const { values } = parseArgs({
     github_token: { type: "string" },
     gitlab_user: { type: "string" },
     forgejo_user: { type: "string" },
+    year: { type: "string" },
+    from: { type: "string" },
+    to: { type: "string" },
     output: { type: "string", multiple: true },
   },
 });
 
-const { github_user, github_token, gitlab_user, forgejo_user, output } = values;
+const { github_user, github_token, gitlab_user, forgejo_user, year, from, to, output } = values;
 
 const set = [github_user, gitlab_user, forgejo_user].filter(Boolean);
 if (set.length === 0) {
@@ -75,6 +78,9 @@ const source: Source = (() => {
       githubToken,
       username,
       baseUrl,
+      year: year ? Number(year) : undefined,
+      from: from,
+      to: to,
     };
   }
 

--- a/packages/generate-snake-animation/generateSnakeAnimation.ts
+++ b/packages/generate-snake-animation/generateSnakeAnimation.ts
@@ -16,6 +16,9 @@ export type Source =
       username: string;
       githubToken: string;
       baseUrl?: string;
+      year?: number;
+      from?: string;
+      to?: string;
     }
   | { platform: "gitlab"; username: string; baseUrl?: string }
   | { platform: "forgejo"; username: string; baseUrl: string };
@@ -32,6 +35,9 @@ export const getUserContribution = async (source: Source) => {
       return getGithubUserContribution(source.username, {
         githubToken: source.githubToken,
         baseUrl: source.baseUrl,
+        year: source.year,
+        from: source.from,
+        to: source.to,
       });
     case "gitlab":
       return getGitlabUserContribution(source.username, {

--- a/packages/github-user-contribution/index.ts
+++ b/packages/github-user-contribution/index.ts
@@ -16,12 +16,33 @@
  */
 export const getGithubUserContribution = async (
   userName: string,
-  o: { githubToken: string; baseUrl?: string },
+  o: {
+    githubToken: string;
+    baseUrl?: string;
+    year?: number;
+    from?: string;
+    to?: string;
+  },
 ) => {
+  const from =
+    o.from ??
+    (o.year !== undefined ? `${o.year}-01-01T00:00:00Z` : undefined);
+
+  const to =
+    o.to ??
+    (o.year !== undefined ? `${o.year}-12-31T23:59:59Z` : undefined);
+
   const query = /* GraphQL */ `
-    query ($login: String!) {
+    query (
+      $login: String!
+      $from: DateTime
+      $to: DateTime
+    ) {
       user(login: $login) {
-        contributionsCollection {
+        contributionsCollection(
+          from: $from
+          to: $to
+        ) {
           contributionCalendar {
             weeks {
               contributionDays {
@@ -36,7 +57,12 @@ export const getGithubUserContribution = async (
       }
     }
   `;
-  const variables = { login: userName };
+
+  const variables = {
+    login: userName,
+    from,
+    to,
+  };
 
   const apiUrl = o.baseUrl
     ? `${o.baseUrl}/api/graphql`


### PR DESCRIPTION
## Overview
This PR introduces the capability to generate the contribution snake animation for a specific calendar year or a custom date range, rather than being restricted strictly to the last 365 rolling days. 

To achieve this flexibility and allow custom runtime execution/compilation via tools like Bun/Yarn inside workflows, the action execution environment has also been migrated from a locked Docker container to a native Node.js setup.

---

## Detailed Changes per File

* **`action.yml`**
  * Added new optional inputs: `year`, `from`, and `to`.
  * Migrated the execution engine (`runs`) from `docker` to `node20` pointing to the compiled distribution path (`packages/action/dist/index.js`).

* **`packages/action/index.ts`**
  * Implemented input extraction for `year`, `from`, and `to` using the GitHub Actions core library.
  * Added parsing logic to cast the `year` string into a valid number (`Number(year)`) before passing it downstream.

* **`packages/generate-snake-animation/cli.ts`**
  * Updated the Command Line Interface (CLI) configuration to properly accept and route the new date-filtering arguments during local execution or debugging.

* **`packages/generate-snake-animation/generateSnakeAnimation.ts`**
  * Updated the animation orchestrator function signature and execution block to forward the time-frame constraints into the data-fetching layer.

* **`packages/github-user-contribution/index.ts`**
  * Modified the internal GraphQL/API query mechanism that communicates with GitHub's servers to fetch explicit historical data scoped to the selected year/range instead of the generic contribution calendar.

---

## How to use this new integration

In your profile workflow `.yml`, clone this custom action branch and pass the `year` parameter like this:

```yaml
- name: Generate Animated Snake
  uses: ./.github/actions/snk-custom # Points to your built local copy of this fork
  with:
    github_user_name: jjceron
    outputs: |
      dist/github-contribution-grid-snake-dark.svg?palette=github-dark
    year: 2026 # Target year configuration